### PR TITLE
Manage the absolute path

### DIFF
--- a/src/StorageProviders.AzureStorage/AzureStorageProvider.cs
+++ b/src/StorageProviders.AzureStorage/AzureStorageProvider.cs
@@ -134,9 +134,9 @@ internal class AzureStorageProvider(AzureStorageSettings settings) : IStoragePro
     {
         path = path?.Replace(@"\", "/") ?? string.Empty;
 
-        // If a container name as been provided in the settings, uses it.
+        // If is relative path and a container name as been provided in the settings, uses it.
         // Otherwise, extracts the first folder name from the path.
-        if (!string.IsNullOrWhiteSpace(settings.ContainerName))
+        if (!path.StartsWith("/") && !string.IsNullOrWhiteSpace(settings.ContainerName))
         {
             return (settings.ContainerName, path);
         }


### PR DESCRIPTION
It would be convenient to be able to manage the absolute path.
To do this I propose to moficate **line 139** of the **AzureStorageProvider.cs** file from so:

`if (!string.IsNullOrWhiteSpace(settings.ContainerName))`

To like this

`if (!path.StartsWith("/") && !string.IsNullOrWhiteSpace(settings.ContainerName))`

I hope my solution is valid.