### PR TITLE
Update package versions in project files

### DIFF
--- a/samples/AzureStorageSample/AzureStorageSample.csproj
+++ b/samples/AzureStorageSample/AzureStorageSample.csproj
@@ -8,8 +8,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-		<PackageReference Include="MinimalHelpers.OpenApi" Version="2.0.15" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+		<PackageReference Include="MinimalHelpers.OpenApi" Version="2.0.16" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
 		<PackageReference Include="TinyHelpers.AspNetCore" Version="3.1.17" />
 	</ItemGroup>
 

--- a/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
+++ b/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup>
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
 		<PackageReference Include="StorageProviders.Abstractions" Version="1.0.16" />
 	</ItemGroup>
 


### PR DESCRIPTION
Updated AzureStorageSample.csproj:
- MinimalHelpers.OpenApi from 2.0.15 to 2.0.16
- Swashbuckle.AspNetCore from 6.8.1 to 6.9.0

Updated StorageProviders.AzureStorage.csproj:
- Azure.Storage.Blobs from 12.22.1 to 12.22.2