### PR TITLE
Update package references in project files

### DIFF
--- a/samples/AzureStorageSample/AzureStorageSample.csproj
+++ b/samples/AzureStorageSample/AzureStorageSample.csproj
@@ -7,11 +7,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-		<PackageReference Include="MinimalHelpers.OpenApi" Version="2.1.6" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.23" />
-		<PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.18" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+		<PackageReference Include="MinimalHelpers.OpenApi" Version="2.1.7" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.26" />
+		<PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.19" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
+++ b/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated versions of several packages in `AzureStorageSample.csproj`, including `Microsoft.AspNetCore.OpenApi`, `MinimalHelpers.OpenApi`, `Swashbuckle.AspNetCore`, `TinyHelpers.AspNetCore`, and `TinyHelpers.AspNetCore.Swashbuckle`.

Also updated `Microsoft.Extensions.Hosting.Abstractions` from `9.0.4` to `9.0.5` in `StorageProviders.AzureStorage.csproj` for the `net9.0` target framework.