### PR TITLE
Add .NET 10.0 support and improve EnumerateAsync method

### DIFF
--- a/src/StorageProviders.AzureStorage/AzureStorageProvider.cs
+++ b/src/StorageProviders.AzureStorage/AzureStorageProvider.cs
@@ -92,7 +92,7 @@ internal class AzureStorageProvider(AzureStorageSettings settings) : IStoragePro
         return Task.FromResult<Uri?>(sharedAccessSignature);
     }
 
-    public async IAsyncEnumerable<string> EnumerateAsync(string? prefix, string[] extensions, [EnumeratorCancellation] CancellationToken cancellationToken)
+    public async IAsyncEnumerable<string> EnumerateAsync(string? prefix, IEnumerable<string> extensions, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var (containerName, pathPrefix) = ExtractContainerBlobName(prefix);
         var blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);

--- a/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
+++ b/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
         <Authors>Marco Minerva</Authors>
         <Company>Marco Minerva</Company>
         <Product>Azure Storage Provider</Product>
@@ -25,13 +25,17 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
-		<PackageReference Include="StorageProviders.Abstractions" Version="1.0.17" />
-	</ItemGroup>
+        <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
+        <PackageReference Include="StorageProviders.Abstractions" Version="1.0.20" />
+    </ItemGroup>
 
     <ItemGroup>
         <None Include="..\..\Toolbox.png">


### PR DESCRIPTION
Updated the `EnumerateAsync` method in `AzureStorageProvider.cs` to use `IEnumerable<string>` for the `extensions` parameter, enhancing flexibility. Added support for .NET 10.0 in `StorageProviders.AzureStorage.csproj` by updating the `<TargetFrameworks>` property and including a new package reference for `Microsoft.Extensions.Hosting.Abstractions` version `10.0.0`.

Updated the `net9.0` package reference for
`Microsoft.Extensions.Hosting.Abstractions` to version `9.0.11`. Upgraded `StorageProviders.Abstractions` to version `1.0.20`. No functional changes were made to project metadata.

Closes #48