### PR TITLE
Switch to NuGet package for Abstractions dependency

### DIFF
--- a/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
+++ b/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
@@ -34,6 +34,7 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+        <PackageReference Include="StorageProviders.Abstractions" Version="1.0.33" />
     </ItemGroup>
 
     <ItemGroup>
@@ -42,10 +43,6 @@
             <PackagePath></PackagePath>
         </None>
         <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\StorageProviders.Abstractions\StorageProviders.Abstractions.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Replaced direct project reference to StorageProviders.Abstractions with a NuGet package reference (version 1.0.33) in the AzureStorage project file. This change improves dependency management and decouples the project from the local source.