### PR TITLE
Update StorageProviders.Abstractions to v1.0.35

### DIFF
--- a/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
+++ b/src/StorageProviders.AzureStorage/StorageProviders.AzureStorage.csproj
@@ -34,7 +34,7 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
-        <PackageReference Include="StorageProviders.Abstractions" Version="1.0.33" />
+        <PackageReference Include="StorageProviders.Abstractions" Version="1.0.35" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgraded the StorageProviders.Abstractions NuGet package from version 1.0.33 to 1.0.35 in the StorageProviders.AzureStorage.csproj file to ensure compatibility with the latest features and bug fixes.