### PR TITLE
Add full XML docs for public APIs and enable doc generation

### DIFF
--- a/.github/workflows/publish_abstractions.yml
+++ b/.github/workflows/publish_abstractions.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         
     - name: Setup .NET SDK ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.NET_VERSION }}
         dotnet-quality: 'ga'

--- a/.github/workflows/publish_azurestorage.yml
+++ b/.github/workflows/publish_azurestorage.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         
     - name: Setup .NET SDK ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.NET_VERSION }}
         dotnet-quality: 'ga'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.10.85"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/StorageProviders.Abstractions/Extensions/AsyncEnumerableExtensions.cs
+++ b/src/StorageProviders.Abstractions/Extensions/AsyncEnumerableExtensions.cs
@@ -1,7 +1,17 @@
 ﻿namespace System.Linq;
 
+/// <summary>
+/// Provides compatibility helpers for working with <see cref="IAsyncEnumerable{T}" /> sequences.
+/// </summary>
 public static class AsyncEnumerableExtensions
 {
+    /// <summary>
+    /// Materializes an <see cref="IAsyncEnumerable{T}" /> into a <see cref="List{T}" /> while honoring cancellation during enumeration.
+    /// </summary>
+    /// <typeparam name="T">The type of items produced by the asynchronous sequence.</typeparam>
+    /// <param name="items">The asynchronous sequence to enumerate.</param>
+    /// <param name="cancellationToken">A token that can stop enumeration before all items have been read.</param>
+    /// <returns>A list containing the items yielded by <paramref name="items" /> in enumeration order.</returns>
     public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> items, CancellationToken cancellationToken = default)
     {
         var results = new List<T>();

--- a/src/StorageProviders.Abstractions/IStorageProvider.cs
+++ b/src/StorageProviders.Abstractions/IStorageProvider.cs
@@ -1,26 +1,79 @@
 ﻿namespace StorageProviders;
 
+/// <summary>
+/// Defines the storage operations that provider implementations expose so application code can work with files without depending on a specific backing service.
+/// </summary>
+/// <remarks>
+/// Implementations translate these operations to storage systems such as cloud object stores, file shares, or other durable stores while preserving consistent behavior for callers.
+/// Paths are provider-defined logical locations; callers should not assume they map to local file-system paths unless a provider documents that behavior.
+/// </remarks>
 public interface IStorageProvider
 {
+    /// <summary>
+    /// Saves binary content to a logical storage path with optional provider-specific metadata.
+    /// </summary>
+    /// <param name="path">The provider-defined destination path for the stored content.</param>
+    /// <param name="content">The bytes to persist.</param>
+    /// <param name="metadata">Optional key/value metadata to associate with the stored object, or <see langword="null" /> when no metadata is required.</param>
+    /// <param name="overwrite"><see langword="true" /> to replace an existing object at <paramref name="path" />; <see langword="false" /> to let the provider protect existing content.</param>
+    /// <param name="cancellationToken">A token that can cancel the save operation.</param>
+    /// <returns>A task that completes when the content has been accepted by the provider.</returns>
     async Task SaveAsync(string path, byte[] content, IDictionary<string, string>? metadata, bool overwrite = false, CancellationToken cancellationToken = default)
     {
         using var stream = new MemoryStream(content);
         await SaveAsync(path, stream, metadata, overwrite, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Saves stream content to a logical storage path with optional provider-specific metadata.
+    /// </summary>
+    /// <param name="path">The provider-defined destination path for the stored content.</param>
+    /// <param name="stream">The readable stream whose current position is used as the start of the content to persist.</param>
+    /// <param name="metadata">Optional key/value metadata to associate with the stored object, or <see langword="null" /> when no metadata is required.</param>
+    /// <param name="overwrite"><see langword="true" /> to replace an existing object at <paramref name="path" />; <see langword="false" /> to let the provider protect existing content.</param>
+    /// <param name="cancellationToken">A token that can cancel the save operation.</param>
+    /// <returns>A task that completes when the content has been accepted by the provider.</returns>
     Task SaveAsync(string path, Stream stream, IDictionary<string, string>? metadata, bool overwrite = false, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Saves binary content to a logical storage path when no metadata needs to be supplied.
+    /// </summary>
+    /// <param name="path">The provider-defined destination path for the stored content.</param>
+    /// <param name="content">The bytes to persist.</param>
+    /// <param name="overwrite"><see langword="true" /> to replace an existing object at <paramref name="path" />; <see langword="false" /> to let the provider protect existing content.</param>
+    /// <param name="cancellationToken">A token that can cancel the save operation.</param>
+    /// <returns>A task that completes when the content has been accepted by the provider.</returns>
     async Task SaveAsync(string path, byte[] content, bool overwrite = false, CancellationToken cancellationToken = default)
     {
         using var stream = new MemoryStream(content);
         await SaveAsync(path, stream, overwrite, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Saves stream content to a logical storage path when no metadata needs to be supplied.
+    /// </summary>
+    /// <param name="path">The provider-defined destination path for the stored content.</param>
+    /// <param name="stream">The readable stream whose current position is used as the start of the content to persist.</param>
+    /// <param name="overwrite"><see langword="true" /> to replace an existing object at <paramref name="path" />; <see langword="false" /> to let the provider protect existing content.</param>
+    /// <param name="cancellationToken">A token that can cancel the save operation.</param>
+    /// <returns>A task that completes when the content has been accepted by the provider.</returns>
     Task SaveAsync(string path, Stream stream, bool overwrite = false, CancellationToken cancellationToken = default)
         => SaveAsync(path, stream, null, overwrite, cancellationToken);
 
+    /// <summary>
+    /// Opens stored content for reading without forcing providers to buffer the entire object in memory.
+    /// </summary>
+    /// <param name="path">The provider-defined path of the stored object to read.</param>
+    /// <param name="cancellationToken">A token that can cancel the read operation before the stream is returned.</param>
+    /// <returns>A readable stream for the object at <paramref name="path" />, or <see langword="null" /> when the object does not exist.</returns>
     Task<Stream?> ReadAsStreamAsync(string path, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Reads stored content into memory for callers that need a byte-array representation.
+    /// </summary>
+    /// <param name="path">The provider-defined path of the stored object to read.</param>
+    /// <param name="cancellationToken">A token that can cancel the read operation.</param>
+    /// <returns>The object content as a byte array, or <see langword="null" /> when the object does not exist.</returns>
     async Task<byte[]?> ReadAsByteArrayAsync(string path, CancellationToken cancellationToken = default)
     {
         using var stream = await ReadAsStreamAsync(path, cancellationToken).ConfigureAwait(false);
@@ -34,38 +87,82 @@ public interface IStorageProvider
         return null;
     }
 
+    /// <summary>
+    /// Resolves a provider-defined path to the absolute <see cref="Uri" /> used to address the stored object.
+    /// </summary>
+    /// <param name="path">The provider-defined path to resolve.</param>
+    /// <param name="cancellationToken">A token that can cancel the path resolution operation.</param>
+    /// <returns>The absolute <see cref="Uri" /> that identifies <paramref name="path" /> for the current provider.</returns>
     Task<Uri> GetFullPathAsync(string path, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets a URI with read access to the specified path that expires at the given date.
+    /// Creates a temporary read-access <see cref="Uri" /> for a stored object when the provider supports delegated access.
     /// </summary>
-    /// <param name="path">The path to the file.</param>
-    /// <param name="expirationDate">The expiration date for the read access URI.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A URI with read access to the file, or <see langword="null" /> if the operation is not supported.</returns>
+    /// <param name="path">The provider-defined path of the object to expose for reading.</param>
+    /// <param name="expirationDate">The date and time after which the returned URI should no longer grant access.</param>
+    /// <param name="cancellationToken">A token that can cancel the URI creation operation.</param>
+    /// <returns>A read-access <see cref="Uri" /> for the object, or <see langword="null" /> when delegated access is not supported by the provider.</returns>
     Task<Uri?> GetReadAccessUriAsync(string path, DateTime expirationDate, CancellationToken cancellationToken = default)
         => GetReadAccessUriAsync(path, expirationDate, fileName: null, cancellationToken);
 
     /// <summary>
-    /// Gets a URI with read access to the specified path that expires at the given date, optionally specifying a file name for the download.
+    /// Creates a temporary read-access <see cref="Uri" /> and optionally suggests a download file name when the provider supports it.
     /// </summary>
-    /// <param name="path">The path to the file.</param>
-    /// <param name="expirationDate">The expiration date for the read access URI.</param>
-    /// <param name="fileName">The optional file name to use for the download. If provided and supported by the provider, the Content-Disposition header will be set to suggest this file name to the browser. If <see langword="null" /> or not supported, the default file name from the storage path will be used.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A URI with read access to the file, or <see langword="null" /> if the operation is not supported.</returns>
+    /// <param name="path">The provider-defined path of the object to expose for reading.</param>
+    /// <param name="expirationDate">The date and time after which the returned URI should no longer grant access.</param>
+    /// <param name="fileName">The optional download name to request from the provider, or <see langword="null" /> to keep the provider's default naming behavior.</param>
+    /// <param name="cancellationToken">A token that can cancel the URI creation operation.</param>
+    /// <returns>A read-access <see cref="Uri" /> for the object, or <see langword="null" /> when delegated access is not supported by the provider.</returns>
     Task<Uri?> GetReadAccessUriAsync(string path, DateTime expirationDate, string? fileName, CancellationToken cancellationToken = default);
-    
+
+    /// <summary>
+    /// Determines whether an object exists at a provider-defined path before callers attempt operations that require it.
+    /// </summary>
+    /// <param name="path">The provider-defined path to check.</param>
+    /// <param name="cancellationToken">A token that can cancel the existence check.</param>
+    /// <returns><see langword="true" /> when an object exists at <paramref name="path" />; otherwise, <see langword="false" />.</returns>
     Task<bool> ExistsAsync(string path, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Enumerates stored object paths using optional prefix and extension filters.
+    /// </summary>
+    /// <param name="prefix">An optional provider-defined path prefix used to narrow the enumeration scope.</param>
+    /// <param name="extensions">Optional file extensions used to include only matching objects.</param>
+    /// <returns>An asynchronous sequence of provider-defined paths that match the supplied filters.</returns>
     IAsyncEnumerable<string> EnumerateAsync(string? prefix = null, params IEnumerable<string> extensions)
         => EnumerateAsync(prefix, extensions, CancellationToken.None);
 
+    /// <summary>
+    /// Enumerates stored object paths using optional prefix and extension filters while allowing cancellation during traversal.
+    /// </summary>
+    /// <param name="prefix">An optional provider-defined path prefix used to narrow the enumeration scope.</param>
+    /// <param name="extensions">Optional file extensions used to include only matching objects.</param>
+    /// <param name="cancellationToken">A token that can cancel enumeration while the provider is scanning storage.</param>
+    /// <returns>An asynchronous sequence of provider-defined paths that match the supplied filters.</returns>
     IAsyncEnumerable<string> EnumerateAsync(string? prefix, IEnumerable<string> extensions, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Removes the object at the specified provider-defined path.
+    /// </summary>
+    /// <param name="path">The provider-defined path of the object to remove.</param>
+    /// <param name="cancellationToken">A token that can cancel the delete operation.</param>
+    /// <returns>A task that completes when the provider has processed the delete request.</returns>
     Task DeleteAsync(string path, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Retrieves provider-neutral information about stored content so callers can inspect metadata without reading the object body.
+    /// </summary>
+    /// <param name="path">The provider-defined path of the object whose properties should be retrieved.</param>
+    /// <param name="cancellationToken">A token that can cancel the property retrieval operation.</param>
+    /// <returns>A <see cref="StorageFileInfo" /> instance describing the stored object.</returns>
     Task<StorageFileInfo> GetPropertiesAsync(string path, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Replaces or clears the provider-specific metadata associated with a stored object.
+    /// </summary>
+    /// <param name="path">The provider-defined path of the object whose metadata should be updated.</param>
+    /// <param name="metadata">The metadata to apply, or <see langword="null" /> when metadata should be cleared or omitted according to provider behavior.</param>
+    /// <param name="cancellationToken">A token that can cancel the metadata update operation.</param>
+    /// <returns>A task that completes when the provider has processed the metadata update.</returns>
     Task SetMetadataAsync(string path, IDictionary<string, string>? metadata = null, CancellationToken cancellationToken = default);
 }

--- a/src/StorageProviders.Abstractions/StorageFileInfo.cs
+++ b/src/StorageProviders.Abstractions/StorageFileInfo.cs
@@ -2,17 +2,39 @@
 
 namespace StorageProviders;
 
+/// <summary>
+/// Represents provider-neutral file details returned by <see cref="IStorageProvider.GetPropertiesAsync(string, CancellationToken)" />.
+/// </summary>
+/// <param name="name">The provider-defined object name used to infer values such as <see cref="ContentType" />.</param>
 public class StorageFileInfo(string name)
 {
+    /// <summary>
+    /// Gets the provider-defined object name used by callers to display or identify the stored file.
+    /// </summary>
     public string Name { get; } = name;
 
+    /// <summary>
+    /// Gets the MIME type inferred from <see cref="Name" />.
+    /// </summary>
     public string ContentType { get; } = MimeUtility.GetMimeMapping(name);
 
+    /// <summary>
+    /// Gets or sets the last time the provider reports that the stored object was modified.
+    /// </summary>
     public DateTimeOffset LastModified { get; set; }
 
+    /// <summary>
+    /// Gets or sets the time the provider reports that the stored object was created.
+    /// </summary>
     public DateTimeOffset CreatedOn { get; set; }
 
+    /// <summary>
+    /// Gets or sets the object length in bytes.
+    /// </summary>
     public long Length { get; set; }
 
+    /// <summary>
+    /// Gets or sets provider-specific metadata associated with the stored object.
+    /// </summary>
     public IDictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 }

--- a/src/StorageProviders.Abstractions/StorageProviders.Abstractions.csproj
+++ b/src/StorageProviders.Abstractions/StorageProviders.Abstractions.csproj
@@ -5,6 +5,7 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
+        <DocumentationFile>StorageProviders.Abstractions.xml</DocumentationFile>
         <RootNamespace>StorageProviders</RootNamespace>
         <Authors>Marco Minerva</Authors>
         <Company>Marco Minerva</Company>
@@ -20,6 +21,10 @@
         <RepositoryBranch>master</RepositoryBranch>
         <PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
+
+    <ItemGroup>
+        <None Remove="StorageProviders.Abstractions.xml" />
+    </ItemGroup>
 
     <ItemGroup>
 		<PackageReference Include="MimeMapping" Version="4.0.0" />

--- a/src/StorageProviders.Abstractions/StorageProviders.Abstractions.xml
+++ b/src/StorageProviders.Abstractions/StorageProviders.Abstractions.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>StorageProviders.Abstractions</name>
+    </assembly>
+    <members>
+        <member name="T:System.Linq.AsyncEnumerableExtensions">
+            <summary>
+            Provides compatibility helpers for working with <see cref="T:System.Collections.Generic.IAsyncEnumerable`1" /> sequences.
+            </summary>
+        </member>
+        <member name="M:System.Linq.AsyncEnumerableExtensions.ToListAsync``1(System.Collections.Generic.IAsyncEnumerable{``0},System.Threading.CancellationToken)">
+            <summary>
+            Materializes an <see cref="T:System.Collections.Generic.IAsyncEnumerable`1" /> into a <see cref="T:System.Collections.Generic.List`1" /> while honoring cancellation during enumeration.
+            </summary>
+            <typeparam name="T">The type of items produced by the asynchronous sequence.</typeparam>
+            <param name="items">The asynchronous sequence to enumerate.</param>
+            <param name="cancellationToken">A token that can stop enumeration before all items have been read.</param>
+            <returns>A list containing the items yielded by <paramref name="items" /> in enumeration order.</returns>
+        </member>
+        <member name="T:StorageProviders.IStorageProvider">
+            <summary>
+            Defines the storage operations that provider implementations expose so application code can work with files without depending on a specific backing service.
+            </summary>
+            <remarks>
+            Implementations translate these operations to storage systems such as cloud object stores, file shares, or other durable stores while preserving consistent behavior for callers.
+            Paths are provider-defined logical locations; callers should not assume they map to local file-system paths unless a provider documents that behavior.
+            </remarks>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.SaveAsync(System.String,System.Byte[],System.Collections.Generic.IDictionary{System.String,System.String},System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Saves binary content to a logical storage path with optional provider-specific metadata.
+            </summary>
+            <param name="path">The provider-defined destination path for the stored content.</param>
+            <param name="content">The bytes to persist.</param>
+            <param name="metadata">Optional key/value metadata to associate with the stored object, or <see langword="null" /> when no metadata is required.</param>
+            <param name="overwrite"><see langword="true" /> to replace an existing object at <paramref name="path" />; <see langword="false" /> to let the provider protect existing content.</param>
+            <param name="cancellationToken">A token that can cancel the save operation.</param>
+            <returns>A task that completes when the content has been accepted by the provider.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.SaveAsync(System.String,System.IO.Stream,System.Collections.Generic.IDictionary{System.String,System.String},System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Saves stream content to a logical storage path with optional provider-specific metadata.
+            </summary>
+            <param name="path">The provider-defined destination path for the stored content.</param>
+            <param name="stream">The readable stream whose current position is used as the start of the content to persist.</param>
+            <param name="metadata">Optional key/value metadata to associate with the stored object, or <see langword="null" /> when no metadata is required.</param>
+            <param name="overwrite"><see langword="true" /> to replace an existing object at <paramref name="path" />; <see langword="false" /> to let the provider protect existing content.</param>
+            <param name="cancellationToken">A token that can cancel the save operation.</param>
+            <returns>A task that completes when the content has been accepted by the provider.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.SaveAsync(System.String,System.Byte[],System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Saves binary content to a logical storage path when no metadata needs to be supplied.
+            </summary>
+            <param name="path">The provider-defined destination path for the stored content.</param>
+            <param name="content">The bytes to persist.</param>
+            <param name="overwrite"><see langword="true" /> to replace an existing object at <paramref name="path" />; <see langword="false" /> to let the provider protect existing content.</param>
+            <param name="cancellationToken">A token that can cancel the save operation.</param>
+            <returns>A task that completes when the content has been accepted by the provider.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.SaveAsync(System.String,System.IO.Stream,System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Saves stream content to a logical storage path when no metadata needs to be supplied.
+            </summary>
+            <param name="path">The provider-defined destination path for the stored content.</param>
+            <param name="stream">The readable stream whose current position is used as the start of the content to persist.</param>
+            <param name="overwrite"><see langword="true" /> to replace an existing object at <paramref name="path" />; <see langword="false" /> to let the provider protect existing content.</param>
+            <param name="cancellationToken">A token that can cancel the save operation.</param>
+            <returns>A task that completes when the content has been accepted by the provider.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.ReadAsStreamAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Opens stored content for reading without forcing providers to buffer the entire object in memory.
+            </summary>
+            <param name="path">The provider-defined path of the stored object to read.</param>
+            <param name="cancellationToken">A token that can cancel the read operation before the stream is returned.</param>
+            <returns>A readable stream for the object at <paramref name="path" />, or <see langword="null" /> when the object does not exist.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.ReadAsByteArrayAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Reads stored content into memory for callers that need a byte-array representation.
+            </summary>
+            <param name="path">The provider-defined path of the stored object to read.</param>
+            <param name="cancellationToken">A token that can cancel the read operation.</param>
+            <returns>The object content as a byte array, or <see langword="null" /> when the object does not exist.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.GetFullPathAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Resolves a provider-defined path to the absolute <see cref="T:System.Uri" /> used to address the stored object.
+            </summary>
+            <param name="path">The provider-defined path to resolve.</param>
+            <param name="cancellationToken">A token that can cancel the path resolution operation.</param>
+            <returns>The absolute <see cref="T:System.Uri" /> that identifies <paramref name="path" /> for the current provider.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.GetReadAccessUriAsync(System.String,System.DateTime,System.Threading.CancellationToken)">
+            <summary>
+            Creates a temporary read-access <see cref="T:System.Uri" /> for a stored object when the provider supports delegated access.
+            </summary>
+            <param name="path">The provider-defined path of the object to expose for reading.</param>
+            <param name="expirationDate">The date and time after which the returned URI should no longer grant access.</param>
+            <param name="cancellationToken">A token that can cancel the URI creation operation.</param>
+            <returns>A read-access <see cref="T:System.Uri" /> for the object, or <see langword="null" /> when delegated access is not supported by the provider.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.GetReadAccessUriAsync(System.String,System.DateTime,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Creates a temporary read-access <see cref="T:System.Uri" /> and optionally suggests a download file name when the provider supports it.
+            </summary>
+            <param name="path">The provider-defined path of the object to expose for reading.</param>
+            <param name="expirationDate">The date and time after which the returned URI should no longer grant access.</param>
+            <param name="fileName">The optional download name to request from the provider, or <see langword="null" /> to keep the provider's default naming behavior.</param>
+            <param name="cancellationToken">A token that can cancel the URI creation operation.</param>
+            <returns>A read-access <see cref="T:System.Uri" /> for the object, or <see langword="null" /> when delegated access is not supported by the provider.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.ExistsAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Determines whether an object exists at a provider-defined path before callers attempt operations that require it.
+            </summary>
+            <param name="path">The provider-defined path to check.</param>
+            <param name="cancellationToken">A token that can cancel the existence check.</param>
+            <returns><see langword="true" /> when an object exists at <paramref name="path" />; otherwise, <see langword="false" />.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.EnumerateAsync(System.String,System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+            Enumerates stored object paths using optional prefix and extension filters.
+            </summary>
+            <param name="prefix">An optional provider-defined path prefix used to narrow the enumeration scope.</param>
+            <param name="extensions">Optional file extensions used to include only matching objects.</param>
+            <returns>An asynchronous sequence of provider-defined paths that match the supplied filters.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.EnumerateAsync(System.String,System.Collections.Generic.IEnumerable{System.String},System.Threading.CancellationToken)">
+            <summary>
+            Enumerates stored object paths using optional prefix and extension filters while allowing cancellation during traversal.
+            </summary>
+            <param name="prefix">An optional provider-defined path prefix used to narrow the enumeration scope.</param>
+            <param name="extensions">Optional file extensions used to include only matching objects.</param>
+            <param name="cancellationToken">A token that can cancel enumeration while the provider is scanning storage.</param>
+            <returns>An asynchronous sequence of provider-defined paths that match the supplied filters.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.DeleteAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Removes the object at the specified provider-defined path.
+            </summary>
+            <param name="path">The provider-defined path of the object to remove.</param>
+            <param name="cancellationToken">A token that can cancel the delete operation.</param>
+            <returns>A task that completes when the provider has processed the delete request.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.GetPropertiesAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Retrieves provider-neutral information about stored content so callers can inspect metadata without reading the object body.
+            </summary>
+            <param name="path">The provider-defined path of the object whose properties should be retrieved.</param>
+            <param name="cancellationToken">A token that can cancel the property retrieval operation.</param>
+            <returns>A <see cref="T:StorageProviders.StorageFileInfo" /> instance describing the stored object.</returns>
+        </member>
+        <member name="M:StorageProviders.IStorageProvider.SetMetadataAsync(System.String,System.Collections.Generic.IDictionary{System.String,System.String},System.Threading.CancellationToken)">
+            <summary>
+            Replaces or clears the provider-specific metadata associated with a stored object.
+            </summary>
+            <param name="path">The provider-defined path of the object whose metadata should be updated.</param>
+            <param name="metadata">The metadata to apply, or <see langword="null" /> when metadata should be cleared or omitted according to provider behavior.</param>
+            <param name="cancellationToken">A token that can cancel the metadata update operation.</param>
+            <returns>A task that completes when the provider has processed the metadata update.</returns>
+        </member>
+        <member name="T:StorageProviders.StorageFileInfo">
+            <summary>
+            Represents provider-neutral file details returned by <see cref="M:StorageProviders.IStorageProvider.GetPropertiesAsync(System.String,System.Threading.CancellationToken)" />.
+            </summary>
+            <param name="name">The provider-defined object name used to infer values such as <see cref="P:StorageProviders.StorageFileInfo.ContentType" />.</param>
+        </member>
+        <member name="M:StorageProviders.StorageFileInfo.#ctor(System.String)">
+            <summary>
+            Represents provider-neutral file details returned by <see cref="M:StorageProviders.IStorageProvider.GetPropertiesAsync(System.String,System.Threading.CancellationToken)" />.
+            </summary>
+            <param name="name">The provider-defined object name used to infer values such as <see cref="P:StorageProviders.StorageFileInfo.ContentType" />.</param>
+        </member>
+        <member name="P:StorageProviders.StorageFileInfo.Name">
+            <summary>
+            Gets the provider-defined object name used by callers to display or identify the stored file.
+            </summary>
+        </member>
+        <member name="P:StorageProviders.StorageFileInfo.ContentType">
+            <summary>
+            Gets the MIME type inferred from <see cref="P:StorageProviders.StorageFileInfo.Name" /> so callers can set response headers without duplicating content-type mapping logic.
+            </summary>
+        </member>
+        <member name="P:StorageProviders.StorageFileInfo.LastModified">
+            <summary>
+            Gets or sets the last time the provider reports that the stored object was modified.
+            </summary>
+        </member>
+        <member name="P:StorageProviders.StorageFileInfo.CreatedOn">
+            <summary>
+            Gets or sets the time the provider reports that the stored object was created.
+            </summary>
+        </member>
+        <member name="P:StorageProviders.StorageFileInfo.Length">
+            <summary>
+            Gets or sets the object length in bytes, allowing callers to reason about transfer size before reading content.
+            </summary>
+        </member>
+        <member name="P:StorageProviders.StorageFileInfo.Metadata">
+            <summary>
+            Gets or sets provider-specific metadata associated with the stored object.
+            </summary>
+        </member>
+    </members>
+</doc>


### PR DESCRIPTION
Comprehensive XML documentation added for all public APIs, including IStorageProvider, AsyncEnumerableExtensions, and StorageFileInfo. Project now generates and ships an XML documentation file. Updated Nerdbank.GitVersioning to 3.10.85.